### PR TITLE
Fix issue template syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-logo.yaml
+++ b/.github/ISSUE_TEMPLATE/new-logo.yaml
@@ -50,7 +50,6 @@ body:
       label: Self-assign
       description: >
         Would you like to follow up this addition yourself?
-      multiple: true
       options:
         - label: Self-assign?
           required: false


### PR DESCRIPTION
Seemingly the 'multiple' option can not be used in an GitHub issue template when there is only one checkbox in the group. This commit removes that option.