### PR TITLE
Add Python and Yocto quickstarts to README

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -8,6 +8,8 @@ Since the requirements and usage for SPDX varies, each quick start will have uni
 | Ecosystem or Community | Quick Start Document | Example(s) | Video | Contact |
 |--|--|--|--|--|
 | Maven | [MavenQuickStart.md](MavenQuickStart.md) | [Full Maven Example](https://github.com/spdx/spdx-maven-plugin/blob/master/src/it/advanced/pom.xml) | N/A | @goneall |
+| [Python Library](https://github.com/spdx/tools-python) | [PythonToolsQuickStart.md](PythonToolsQuickStart.md) | [Python Tools Examples](https://github.com/spdx/tools-python/tree/main/examples) | N/A | @armintaenzertng |
+| [Yocto](https://www.yoctoproject.org/) | [Creating a Software Bill of Materials in Yocto](https://docs.yoctoproject.org/dev-manual/sbom.html) | N/A | [Automated SBoM generation with OpenEmbedded and the Yocto Project](https://youtu.be/Q5UQUM6zxVU) | @JPEWdev |
 
 ## Upcoming Quick Starts
 


### PR DESCRIPTION
Adds two rows to the quick start README file:
- Python libraries
- Yocto